### PR TITLE
Fix crash if subcontent and no library selected

### DIFF
--- a/src/scripts/questionnaire.js
+++ b/src/scripts/questionnaire.js
@@ -55,6 +55,10 @@ export default class Questionnaire extends H5P.EventDispatcher {
       content.className = 'h5p-questionnaire-content';
 
       questionnaireElements.forEach(({requiredField, library}, index) => {
+        if (typeof library !== 'object' || !library.library) {
+          return; // No library selected
+        }
+
         const questionContent = this.createQuestionContent(requiredField, library, index);
         content.appendChild(questionContent.getElement());
         this.state.questionnaireElements.push(questionContent);


### PR DESCRIPTION
Currently, if Questionnaire is used as subcontent (e.g. in Interactive Video) and no content library is selected when concluding editing Questionnaire, it will crash.

When merged in, this will be fixed by checking whether a library has not been set.